### PR TITLE
improvement to format description

### DIFF
--- a/_rfcs/auditable-collection-example/createCollection.sh
+++ b/_rfcs/auditable-collection-example/createCollection.sh
@@ -10,7 +10,7 @@ function sha256UrlSafe  {
 #
 function createOrderSubdirectoryWithOrder {
   mkdir downloadable-collection/$1
-  cp $2 downloadable-collection/$1/order.json
+  cp $2 downloadable-collection/$1/order
 }
 
 #
@@ -19,8 +19,8 @@ function createOrderSubdirectoryWithOrder {
 function createOrderFromTemplate {
   source $1
   baseName=$(basename `pwd`/raw-orders/$1 .sh)
-  orderFile=raw-orders/$baseName.json
-  echo $ORDER > $orderFile
+  orderJson=raw-orders/$baseName.json
+  echo $ORDER > $orderJson
 }
 
 
@@ -28,7 +28,7 @@ function createOrderFromTemplate {
 # computes retailer signature over raw order bytes
 #
 function writeRetailerSignature {
-  RETAILER_SIG_BASE64=$(openssl dgst -sha256 -binary -sign retailer/retailer-private_key.pem downloadable-collection/$1/order.json | base64)
+  RETAILER_SIG_BASE64=$(openssl dgst -sha256 -binary -sign retailer/retailer-private_key.pem downloadable-collection/$1/order | base64)
 
   RETAILER_SIGN_JSON=$(cat <<EOF
 {
@@ -45,7 +45,7 @@ EOF
 # writes operator acceptance document for order
 #
 function writeOperatorAcceptance {
-  RETAILER_ORDER_REFERENCE=$(jq '.metadata."retailer-order-reference"' -r downloadable-collection/$1/order.json)
+  RETAILER_ORDER_REFERENCE=$(jq '.metadata."retailer-order-reference"' -r downloadable-collection/$1/order)
   ORDER_ACCEPTANCE=$(cat <<EOF
 {
   "order-digest": "sha256:$1",
@@ -144,8 +144,8 @@ before
 
 for order in $(ls raw-orders/*.sh); do
   createOrderFromTemplate $order
-  orderSha=`sha256UrlSafe $orderFile`
-  createOrderSubdirectoryWithOrder $orderSha $orderFile
+  orderSha=`sha256UrlSafe $orderJson`
+  createOrderSubdirectoryWithOrder $orderSha $orderJson
   writeRetailerSignature $orderSha
   writeOperatorAcceptance $orderSha
   writeOperatorSignature $orderSha

--- a/_rfcs/auditable-collection-example/validateCollection.sh
+++ b/_rfcs/auditable-collection-example/validateCollection.sh
@@ -17,7 +17,7 @@ function sha256UrlSafe  {
 
 function compareOrderWithHashInDirectory {
   # compute hash of order.json and see if matches the directory hash...
-  orderSha=$(sha256UrlSafe validation/downloadable-collection/$1/order.json)
+  orderSha=$(sha256UrlSafe validation/downloadable-collection/$1/order)
   if [ $orderSha = $1 ]
     then
       echo "order hash matches directory name... OK"
@@ -32,7 +32,7 @@ function checkRetailerSignature {
   openssl dgst -sha256 \
     -verify retailer/retailer-public_key.pem \
     -signature validation/downloadable-collection/$1/order.signature.raw \
-    validation/downloadable-collection/$1/order.json
+    validation/downloadable-collection/$1/order
   echo "validated retailer signature..."
 }
 

--- a/_rfcs/downloadable-auditable-order-collection.md
+++ b/_rfcs/downloadable-auditable-order-collection.md
@@ -49,13 +49,13 @@ The data for each order is placed in a directory named according to the URL-safe
 
 Within this directory the files with the following names and semantics are expected to be present:
 
-* `order.json` (the raw order data as submitted by the [Retailer](../concepts/retailer)).
-* `order.signature` (the retailer signature over the order). A properties file with three string properties corresponding to those defined for [Content-Signature](content-signature:)
+* `order` (the raw order data in JSON format as submitted by the [Retailer](../concepts/retailer)).
+* `order.signature` (the retailer signature over the order). A JSON file with a single object with three string properties corresponding to those defined for [Content-Signature](content-signature:)
    * `algorithm`. The standardised (as per [Content-Signature](content-signature)) algorithm name for the signature algorithm used.
    * `keyId`. The key alias for the key pair used to produce the signature.
    * `signature`. The base64 encoded signature.
-* `order.result` (the terminal [order processing state](../concepts/order-processing-state) document from the operator in JSON format. This includes an `order-digest` field over the `order.json` which allows the processing result to be correlated with the input `order`).
-* `order.result.signature`. A properties file with the same three string properties as for the retailer signature.
+* `order.result` (the terminal [order processing state](../concepts/order-processing-state) document from the operator in JSON format. This includes an `order-digest` field over the `order` document which allows the processing result to be correlated with the input `order`).
+* `order.result.signature`. A JSON file with a single object with the same three string properties as for the retailer signature.
   * `algorithm`.
   * `keyId`. The key alias for the key pair used to produce the signature.
   * `signature`. The base64 encoded signature.


### PR DESCRIPTION
Describes signatures documents as JSON.
Renames order.json to order.
Adjusts example scripts to take account of above.

Basic reasoning is that mix of JSON and properties is not very
consistent.
